### PR TITLE
Android should match iOS callback

### DIFF
--- a/android/src/main/java/com/yoloci/fileupload/FileUploadModule.java
+++ b/android/src/main/java/com/yoloci/fileupload/FileUploadModule.java
@@ -152,22 +152,19 @@ public class FileUploadModule extends ReactContextBaseJavaModule {
                     sb.append(line);
                 }
                 br.close();
-                JSONObject mainObject = new JSONObject(sb.toString());
-                if (mainObject != null) {
-                    BundleJSONConverter bjc = new BundleJSONConverter();
-                    Bundle bundle = bjc.convertToBundle(mainObject);
-                    WritableMap map = Arguments.fromBundle(bundle);
+                String data = sb.toString();
+                JSONObject mainObject = new JSONObject();
+                mainObject.put("data", data);
+                mainObject.put("status", serverResponseCode);
 
-                    fileInputStream.close();
-                    outputStream.flush();
-                    outputStream.close();
-                    callback.invoke(null, map);
-                } else {
-                    fileInputStream.close();
-                    outputStream.flush();
-                    outputStream.close();
-                    callback.invoke(null, null);
-                }
+                BundleJSONConverter bjc = new BundleJSONConverter();
+                Bundle bundle = bjc.convertToBundle(mainObject);
+                WritableMap map = Arguments.fromBundle(bundle);
+
+                fileInputStream.close();
+                outputStream.flush();
+                outputStream.close();
+                callback.invoke(null, map);
             }
 
 
@@ -177,5 +174,3 @@ public class FileUploadModule extends ReactContextBaseJavaModule {
         }
     }
 }
-
-


### PR DESCRIPTION
Ideally, the api should be the same for iOS and android.

Currently, the iOS module returns:

```
  NSDictionary *res=[[NSDictionary alloc] initWithObjectsAndKeys:[NSNumber numberWithInteger:statusCode],@"status",returnString,@"data",nil];
```

This pull request is to match that implementation.  While you could change the iOS module, I think the iOS implementation is more composable. 
