### PR TITLE
Ids 18357 - support content URI for android filepaths

### DIFF
--- a/android/src/main/java/com/yoloci/fileupload/FileUploadModule.java
+++ b/android/src/main/java/com/yoloci/fileupload/FileUploadModule.java
@@ -3,13 +3,23 @@ package com.yoloci.fileupload;
 import android.app.Activity;
 import android.os.Bundle;
 
-import com.facebook.react.bridge.*;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableMapKeySetIterator;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.WritableMap;
 import org.json.JSONObject;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.DataInputStream;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.HashMap;
 import java.util.Map;
 
 import android.provider.MediaStore;
@@ -122,7 +132,6 @@ public class FileUploadModule extends ReactContextBaseJavaModule {
                 ReadableMap file = files.getMap(i);
                 String filepath = file.getString("filepath");
                 String filename = null;
-                Map<String,String> fileInfo = null;
                 if (filepath.matches("content://.*")) {
                     filepath = getFilePath(filepath);
                 }

--- a/android/src/main/java/com/yoloci/fileupload/FileUploadPackage.java
+++ b/android/src/main/java/com/yoloci/fileupload/FileUploadPackage.java
@@ -1,5 +1,6 @@
 package com.yoloci.fileupload;
 
+import android.app.Activity;
 
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
@@ -15,9 +16,10 @@ import java.util.List;
 
 public class FileUploadPackage implements ReactPackage {
     private FileUploadModule mModule;
+    private Activity mActivity = null;
 
-    public FileUploadPackage() {
-
+    public FileUploadPackage(Activity activity) {
+        mActivity = activity;
     }
 
     @Override
@@ -25,7 +27,7 @@ public class FileUploadPackage implements ReactPackage {
             ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();
 
-        mModule = new FileUploadModule(reactContext);
+        mModule = new FileUploadModule(reactContext, mActivity);
         modules.add(mModule);
         return modules;
     }


### PR DESCRIPTION
Allow users to pass a content uri ex: "content://media/images/35" and resolve it back to a filepath to get the filename and upload. Also allow users to not pass filename and deduct it from the filepath.
