### PR TITLE
Add Android support for name parameter, addressing issue #31

### DIFF
--- a/android/src/main/java/com/yoloci/fileupload/FileUploadModule.java
+++ b/android/src/main/java/com/yoloci/fileupload/FileUploadModule.java
@@ -109,11 +109,12 @@ public class FileUploadModule extends ReactContextBaseJavaModule {
                 ReadableMap file = files.getMap(i);
                 String filename = file.getString("filename");
                 String filepath = file.getString("filepath");
+                String name = file.hasKey("name") ? file.getString("name") : filename;
                 filepath = filepath.replace("file://", "");
                 fileInputStream = new FileInputStream(filepath);
 
                 outputStream.writeBytes(twoHyphens + boundary + lineEnd);
-                outputStream.writeBytes("Content-Disposition: form-data; name=\"image\";filename=\"" + filename + "\"" + lineEnd);
+                outputStream.writeBytes("Content-Disposition: form-data; name=\"" + name + "\";filename=\"" + filename + "\"" + lineEnd);
                 outputStream.writeBytes(lineEnd);
 
                 bytesAvailable = fileInputStream.available();


### PR DESCRIPTION
This addresses issue #31 so that the name parameter behaves in Android the same as it does in the iOS implemenation, and also matches the documentation.
- if `name` parameter is specified, send the value provided.
- if `name` is not specified, use the value of the `filename` parameter instead

Previously a fixed value of `image` is always sent.
